### PR TITLE
Fix a bug where Centos-7 was used. Possible cause of pdf_printer rpm getting built for systemd vs sysV

### DIFF
--- a/builder-setup/Makefile.docker
+++ b/builder-setup/Makefile.docker
@@ -12,7 +12,7 @@ DOCKER_PASSWORD := $$(cat ~/.jfrog/jfrog-cli.conf | jq -r '.artifactory | .[] | 
 build:
 	@echo "$(DOCKER_PASSWORD)" | sudo docker login $(DOCKER_REPOSITORY) -u="$(DOCKER_USERNAME)" --password-stdin
 	@sudo docker pull $(DOCKER_REPOSITORY)/package-centos6
-	$(eval ID := $(shell sudo docker create -i -u $(BUILD_USER) -w $(BUILD_HOME) $(DOCKER_REPOSITORY)/package-centos7 /bin/bash -l -c "export BUILD_BRANCH=$(BUILD_BRANCH) && cat /etc/centos-release && make build && ls $(BUILD_HOME)/pdf_printer_rpms"))
+	$(eval ID := $(shell sudo docker create -i -u $(BUILD_USER) -w $(BUILD_HOME) $(DOCKER_REPOSITORY)/package-centos6 /bin/bash -l -c "export BUILD_BRANCH=$(BUILD_BRANCH) && cat /etc/centos-release && make build && ls $(BUILD_HOME)/pdf_printer_rpms"))
 	@echo Container ID is $(ID)
 	sudo docker cp Makefile $(ID):$(BUILD_HOME)/Makefile
 	sudo docker cp ../builder-setup $(ID):$(BUILD_HOME)/


### PR DESCRIPTION
…getting built for systemd vs sysV