### PR TITLE
[UVFS-8140]: Build Setup for pdf_printer

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,18 +1,8 @@
 targets:
-  ubuntu-14.04:
-
+  centos-7:
 user: tetter
 group: tetter
-
-# pkgr's buildpack uses libyaml 0.1.6, which has started failing on build_curl
-# We forked and bumped to version 0.1.7
-# buildpack: https://github.com/TetrationAnalytics/heroku-buildpack-ruby#build_curl-libyaml-0.1.7
-# buildpack: https://github.com/heroku/heroku-buildpack-nodejs#v159
-# env:
- # - BUILDCURL_URL=buildcurl-b4.tetrationanalytics.com
-
-# The rpm is built with a blank production.log, which will clobber existing logs on deploy
-# ditto for noisy.log
-# after:
-#   - rm -rf log/noisy.log
-#   - rm -rf log/production.log
+buildpack: https://github.com/heroku/heroku-buildpack-nodejs#v159
+env:
+  - "HOME=/home/tetter"
+after_install: ./bin/postinstall.sh

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e -x
+
+LOGS_DIR=/local/logs/tetration/pdf-printer
+
+mkdir -p ${LOGS_DIR}
+chown -R ${APP_USER}:${APP_GROUP} ${LOGS_DIR}
+


### PR DESCRIPTION
* Build rpm instead of deb for deploying on CentOS7.X VMs
* Post instal script to own log files